### PR TITLE
fix non-amiga builds and add travis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tundra*
 tundra-output
 t2-output
+/vbcc/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: c
+
+cache:
+  directories:
+    - tundra
+    - vbcc
+
+addons:
+  apt:
+    packages:
+      - p7zip-full
+
+before_install:
+  - export PATH=$PATH:$PWD/tundra/bin
+  - export VBCC=$PWD/vbcc
+
+install:
+  - if [ ! -f tundra/bin/tundra2 ]; then git clone --recurse-submodules https://github.com/deplinenoise/tundra.git t2-build && cd t2-build && make -j 4 && PREFIX=$PWD/../tundra make install && cd - ; fi
+  - if [ ! -f vbcc/bin/vbccm68k ]; then ./build_vbcc.sh ; fi
+
+script:
+  - tundra2 release
+  - tundra2 -j 1 amiga-vbcc-release

--- a/build_vbcc.sh
+++ b/build_vbcc.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -e
+
+check_cmd () { hash $1 2>/dev/null && { echo >&2 "'$1' found"; } || { echo >&2 "'$1' is required, but not found."; exit 1; }; }
+
+check_cmd wget
+check_cmd 7z
+check_cmd patch
+
+export VBCC=$PWD/vbcc
+
+rm -rf $VBCC
+mkdir -p $VBCC
+pushd $VBCC
+
+mkdir -p bin
+mkdir -p config
+mkdir -p targets
+
+cat << 'EOF' | sed -e s:%%VBCC%%:$VBCC:g | sed -e 's:/\([a-z]\)/:\1\:/:g' > config/vc.config
+-cc=%%VBCC%%/bin/vbccm68k -quiet -hunkdebug %s -o= %s %s -O=%ld -I"%%VBCC%%/targets/m68k-amigaos/include" -I"%%VBCC%%/targets/m68k-amigaos/ndkinclude" -I"%%VBCC%%/targets/m68k-amigaos/netinclude"
+-ccv=%%VBCC%%/bin/vbccm68k       -hunkdebug %s -o= %s %s -O=%ld -I"%%VBCC%%/targets/m68k-amigaos/include" -I"%%VBCC%%/targets/m68k-amigaos/ndkinclude" -I"%%VBCC%%/targets/m68k-amigaos/netinclude"
+-as=%%VBCC%%/bin/vasmm68k_mot -quiet -Fhunk -phxass -opt-fconst -nowarn=62 %s -o %s
+-asv=%%VBCC%%/bin/vasmm68k_mot       -Fhunk -phxass -opt-fconst -nowarn=62 %s -o %s
+-rm=rm %s
+-rmv=rm %s
+-ld=%%VBCC%%/bin/vlink  -bamigahunk -x -Bstatic -Cvbcc -nostdlib "%%VBCC%%/targets/m68k-amigaos/lib/startup.o"    %s %s -L"%%VBCC%%/targets/m68k-amigaos/lib" -lvc -lamiga -o %s
+-l2=%%VBCC%%/bin/vlink  -bamigahunk -x -Bstatic -Cvbcc -nostdlib                                                  %s %s -L"%%VBCC%%/targets/m68k-amigaos/lib"              -o %s
+-ldv=%%VBCC%%/bin/vlink -bamigahunk -t -x -Bstatic -Cvbcc -nostdlib "%%VBCC%%/targets/m68k-amigaos/lib/startup.o" %s %s -L"%%VBCC%%/targets/m68k-amigaos/lib" -lvc         -o %s
+-l2v=%%VBCC%%/bin/vlink -bamigahunk -t -x -Bstatic -Cvbcc -nostdlib                                               %s %s -L"%%VBCC%%/targets/m68k-amigaos/lib"              -o %s
+-ldnodb=-s -Rshort
+-ul=-l%s
+-cf=-F%s
+-ml=500
+EOF
+cp config/vc.config config/vc.cfg
+
+wget --no-check-certificate https://server.owl.de/~frank/tags/vbcc0_9g.tar.gz
+tar xzf vbcc0_9g.tar.gz
+patch -p 0 << 'EOF'
+diff -rupN vbcc/datatypes/dtgen.c vbcc.patch/datatypes/dtgen.c
+--- vbcc/datatypes/dtgen.c	2013-04-24 00:45:50 +0200
++++ vbcc.patch/datatypes/dtgen.c	2020-01-01 21:11:42 +0100
+@@ -133,8 +133,7 @@ int askyn(char *def)
+   do{
+     printf("Type y or n [%s]: ",def);
+     fflush(stdout);
+-    fgets(in,sizeof(in),stdin);
+-    if(*in=='\n') strcpy(in,def);
++    strcpy(in,def);
+   }while(*in!='y'&&*in!='n');
+   return *in=='y';
+ }
+@@ -144,9 +143,7 @@ char *asktype(char *def)
+   char *in=mymalloc(128);
+   printf("Enter that type[%s]: ",def);
+   fflush(stdout);
+-  fgets(in,127,stdin);
+-  if(in[strlen(in)-1]=='\n') in[strlen(in)-1]=0;
+-  if(!*in) strcpy(in,def);
++  strcpy(in,def);
+   return in;
+ }
+EOF
+cd vbcc && mkdir bin && make TARGET=m68k -j 4 && cp bin/vc ../bin && cp bin/vbccm68k ../bin && cd -
+rm -rf vbcc vbcc*.tar.gz
+
+wget --no-check-certificate http://server.owl.de/~frank/vbcc/2019-10-04/vbcc_target_m68k-amigaos.lha
+7z x vbcc_target_m68k-amigaos.lha
+cd vbcc_target_m68k-amigaos && mv targets/m68k-amigaos ../targets/m68k-amigaos && cd -
+rm -rf vbcc_target_m68k-amigaos*
+
+wget http://sun.hasenbraten.de/vlink/release/vlink.tar.gz
+tar xzf vlink.tar.gz
+cd vlink && make -j 4 && cp vlink ../bin && cd -
+rm -rf vlink vlink.tar.gz
+
+wget http://sun.hasenbraten.de/vasm/release/vasm.tar.gz
+tar xzf vasm.tar.gz
+cd vasm && make CPU=m68k SYNTAX=mot -j 4 && cp vasmm68k_mot ../bin && cd -
+rm -rf vasm vasm.tar.gz
+
+wget http://www.haage-partner.de/download/AmigaOS/NDK39.lha
+7z x -y NDK39.lha NDK_3.9
+cd NDK_3.9 && mv Include/include_h ../targets/m68k-amigaos/ndkinclude && cd -
+rm -rf NDK_3.9 NDK39.lha
+
+wget http://aminet.net/comm/tcp/AmiTCP-SDK-4.3.lha
+7z x -y AmiTCP-SDK-4.3.lha AmiTCP-SDK-4.3
+cd AmiTCP-SDK-4.3 && mv netinclude ../targets/m68k-amigaos/netinclude && cd -
+rm -rf AmiTCP-SDK-4.3 AmiTCP-SDK-4.3.lha
+
+popd

--- a/src/file_server.c
+++ b/src/file_server.c
@@ -41,11 +41,6 @@ rl_proto_neterror_t translate_posix_errno(void)
 	}
 }
 
-static INLINE int reply_with_posix_errno(peer_t *peer, const rl_msg_t *msg)
-{
-	return reply_with_error(peer, msg, translate_posix_errno());
-}
-
 #endif
 
 

--- a/src/util.c
+++ b/src/util.c
@@ -284,8 +284,10 @@ static char *log_cursor = &log_buffer[0];
 static char * const log_max = &log_buffer[sizeof(log_buffer)-1];
 
 
+#ifdef RL_AMIGA
 void __RawPutChar(__reg("a6") void *, __reg("d0") char ch)="\tjsr\t-516(a6)";
 #define RawPutChar(ch) __RawPutChar(SysBase, (ch))
+#endif
 
 static void log_flush()
 {

--- a/tundra.lua
+++ b/tundra.lua
@@ -53,10 +53,10 @@ Build {
 		Codegen = { Name = "Generate Code", BuildOrder = 1 },
 	},
 	Configs = {
-		Config { Name = "linux-gcc", DefaultOnHost = "linux", Tools = { "gcc" }, },
+		Config { Name = "linux-gcc", DefaultOnHost = "linux", Tools = { "gcc" }, Inherit = common },
 		Config { Name = "macosx-gcc", DefaultOnHost = "macosx", Tools = { "gcc-osx" }, Inherit = osx },
 		Config { Name = "win64-msvc", DefaultOnHost = "windows", Tools = { { "msvc-vs2015"; TargetPlatform = "x64" }, }, Inherit = win, },
-		Config { Name = "amiga-vbcc", Inherit = amiga, Tools = { "vbcc" }, SupportedHosts = { "macosx", "windows" } },
+		Config { Name = "amiga-vbcc", Inherit = amiga, Tools = { "vbcc" }, SupportedHosts = { "macosx", "windows", "linux" } },
 	},
 	Units = "units.lua",
 	ScriptDirs = { "." },


### PR DESCRIPTION
- Fixed compilation errors w/ hosts builds; some lines of Amiga code wasn't #ifdef'd
- Added a Travis-CI build script to protect against future mishaps (like the one above)
- Added a build_vbcc.sh (linux/macos) to enable Travis-CI builds also for Amiga

( https://travis-ci.org/github/erique/rlaunch )